### PR TITLE
Feat: email 중복 검사 api endpoint 분리 및 password 수정시 password 값 비교

### DIFF
--- a/users/serializers.py
+++ b/users/serializers.py
@@ -72,8 +72,9 @@ class UserUpdateSerializer(serializers.ModelSerializer[CustomUser]):
 
         if validated_data.get("password", "") != "":
             password = validated_data["password"]
-            instance.password = make_password(password)
-
+            if instance.check_password(password):
+                raise serializers.ValidationError({"message": "이미 사용중인 비밀번호 입니다."})
+            instance.set_password(password)
         instance.save()
         return instance
 

--- a/users/urls.py
+++ b/users/urls.py
@@ -5,6 +5,7 @@ from .views import (
     KakaoSignInView,
     SignOutAPIView,
     SignUpAPIView,
+    EmailCheckAPIView,
     TokenRefreshView,
     UserDetailView,
     UserProfileImageView,
@@ -12,7 +13,7 @@ from .views import (
 
 urlpatterns = [
     path("sign-up/", SignUpAPIView.as_view(), name="sign-up"),
-    path("email-check/", SignUpAPIView.as_view(), name="sign-up"),
+    path("email-check/", EmailCheckAPIView.as_view(), name="email-check"),
     path("sign-in/", SignInAPIView.as_view(), name="sign-in"),
     path("kakao/sign-in/", KakaoSignInView.as_view(), name="kakao-sign-in"),
     path("sign-out/", SignOutAPIView.as_view(), name="sign-out"),

--- a/users/urls.py
+++ b/users/urls.py
@@ -12,6 +12,7 @@ from .views import (
 
 urlpatterns = [
     path("sign-up/", SignUpAPIView.as_view(), name="sign-up"),
+    path("email-check/", SignUpAPIView.as_view(), name="sign-up"),
     path("sign-in/", SignInAPIView.as_view(), name="sign-in"),
     path("kakao/sign-in/", KakaoSignInView.as_view(), name="kakao-sign-in"),
     path("sign-out/", SignOutAPIView.as_view(), name="sign-out"),

--- a/users/views.py
+++ b/users/views.py
@@ -24,20 +24,30 @@ class SignUpAPIView(APIView):
     serializer_class = SignUpSerializer
 
     def post(self, request):
-        email = request.data.get("email")
-        user = CustomUser.objects.filter(email=email).exists()
-        if user:
-            return Response(
-                data={
-                    "message": "이미 등록된 이메일 입니다.",
-                },
-                status=status.HTTP_409_CONFLICT,
-            )
         serializer = self.serializer_class(data=request.data)
         if serializer.is_valid():
             serializer.save()
             return Response(data={"message": "Successfully Sign Up"}, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+
+class EmailCheckAPIView(APIView):
+    def post(self, request):
+        email = request.data.get("email")
+        user = CustomUser.objects.filter(email=email).exists()
+        if not user:
+            return Response(
+                data={
+                    "message": "사용 가능한 이메일 주소 입니다."
+                },
+                status=status.HTTP_200_OK
+            )
+        return Response(
+            data={
+                "message": "중복된 이메일 주소 입니다."
+            },
+            status=status.HTTP_409_CONFLICT
+        )
 
 
 class SignInAPIView(TokenObtainPairView):


### PR DESCRIPTION
### Pull Request

> ### Title
>
> - Feat: email 중복 검사 api endpoint 분리 및 password 수정시 password 값 비교

> ### PR Type
>
> - [x] FEAT: 새로운 기능 구현
> - [ ] FIX: 버그 수정
> - [ ] DOCS: 문서 추가 및 수정
> - [ ] STYLE: 스타일 (코드 형식, 세미콜론 추가: 비즈니스 로직에 변경 없음)
> - [ ] REFACTOR: 코드 리팩토링 (동작 변경 없음)
> - [ ] TEST: 테스트 관련
> - [ ] DEPLOY: 배포 관련
> - [ ] CONF: 빌드, 환경 설정
> - [ ] CHORE: 기타 변경사항 (빌드 스크립트 수정 등)
> - [ ] REMOVE: 파일 삭제하는 작업만 수행한 경우

> ### Description
>
> - email 중복 검사 api endpoint 회원가입 로직 안에서 처리하던거 분리
> - password 수정시에 이미 사용중이던 password로 수정 요청할 경우 이미사용중인 비밀번호라고 에러처리

> ### Discussion
>
